### PR TITLE
print a more useful error message

### DIFF
--- a/simplegist/simplegist.py
+++ b/simplegist/simplegist.py
@@ -104,5 +104,5 @@ class Simplegist:
 
 			}
 			return response
-		raise Exception('Gist not created.')
+		raise Exception('Gist not created: server response was [%s] %s' % (r.status_code, r.text))
 


### PR DESCRIPTION
Something changed recently with gists and a public setting of 1 no longer worked. Github returned a useful error message but this wasn't passed on me. I've changed the exception handler to return the status code and message for easier future problem solving.

Cheers,
Matt
