### PR TITLE
Include 'files' section of the server response

### DIFF
--- a/simplegist/simplegist.py
+++ b/simplegist/simplegist.py
@@ -98,7 +98,7 @@ class Simplegist:
 			'Embed-Script': '<script src="%s/%s/%s.js"</script>' %(GIST_URL,self.username,r.json()['id']),
 			'id': r.json()['id'],
 			'created_at': r.json()['created_at'],
-
+			'files': r.json()['files'],
 			}
 			return response
 		raise Exception('Gist not created: server response was [%s] %s' % (r.status_code, r.text))


### PR DESCRIPTION
Often one needs information from the 'files' section of the Gist response. For example, it contains the raw URL of the created gist, which cannot be derived from other fields. Thus, it would be great to include this section in the output of the 'create' function, so that the user is able to employ this data straight away.